### PR TITLE
Revert "Update ghcr.io/fluxcd/source-controller Docker tag to v1.3.0"

### DIFF
--- a/home-cluster/flux-system/gotk-components.yaml
+++ b/home-cluster/flux-system/gotk-components.yaml
@@ -3624,7 +3624,7 @@ spec:
               fieldPath: metadata.namespace
         - name: TUF_ROOT
           value: /tmp/.sigstore
-        image: ghcr.io/fluxcd/source-controller:v1.3.0
+        image: ghcr.io/fluxcd/source-controller:v1.2.5
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:


### PR DESCRIPTION
Reverts 1Solon/Home-Server-Configuration#48

1.3.0 seems to have an issue, I'll revert it and check the next version release