### PR TITLE
chore(envoy): prepare gateway 1.9 upgrade

### DIFF
--- a/kubernetes/networking/envoy-gateway/app/kustomization.yaml
+++ b/kubernetes/networking/envoy-gateway/app/kustomization.yaml
@@ -3,4 +3,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./migration.yaml
   - ./release.yaml

--- a/kubernetes/networking/envoy-gateway/app/migration.yaml
+++ b/kubernetes/networking/envoy-gateway/app/migration.yaml
@@ -1,0 +1,119 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: envoy-gateway-migration
+  namespace: networking
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: envoy-gateway-migration
+rules:
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [validatingadmissionpolicies]
+    resourceNames: [safe-upgrades.gateway.networking.k8s.io]
+    verbs: [get, patch]
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [validatingadmissionpolicybindings]
+    resourceNames: [safe-upgrades.gateway.networking.k8s.io]
+    verbs: [get, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: envoy-gateway-migration
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: envoy-gateway-migration
+subjects:
+  - kind: ServiceAccount
+    name: envoy-gateway-migration
+    namespace: networking
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: envoy-gateway-adopt-safe-upgrades
+  namespace: networking
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: envoy-gateway-adopt-safe-upgrades
+    spec:
+      serviceAccountName: envoy-gateway-migration
+      restartPolicy: Never
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        runAsGroup: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      initContainers:
+        - name: label-policy
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [label, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, app.kubernetes.io/managed-by=Helm, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: annotate-policy-release
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-name=envoy-gateway, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: annotate-policy-namespace
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-namespace=networking, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: label-binding
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [label, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, app.kubernetes.io/managed-by=Helm, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: annotate-binding-release
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-name=envoy-gateway, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: annotate-binding-namespace
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-namespace=networking, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+      containers:
+        - name: verify
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [get, validatingadmissionpolicy/safe-upgrades.gateway.networking.k8s.io, validatingadmissionpolicybinding/safe-upgrades.gateway.networking.k8s.io]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]

--- a/kubernetes/networking/envoy-gateway/config/envoy.yaml
+++ b/kubernetes/networking/envoy-gateway/config/envoy.yaml
@@ -110,7 +110,7 @@ spec:
   targetSelectors:
     - group: gateway.networking.k8s.io
       kind: Gateway
-  compression:
+  compressor:
     - type: Brotli
     - type: Gzip
     - type: Zstd


### PR DESCRIPTION
## What changed

- Rename only `BackendTrafficPolicy.spec.compression` to `spec.compressor`, as required for the Envoy Gateway 1.9 API. The separate EnvoyProxy telemetry `compression` field is unchanged.
- Add a temporary declarative ServiceAccount, narrowly scoped ClusterRole/Binding, and Job to adopt the existing safe-upgrade admission resources into the Helm release.
- Keep the Envoy Gateway chart pinned to 1.8.3. This PR does not perform the 1.9 upgrade.

## Adoption scope

The Job changes ownership metadata on exactly these cluster-scoped resources:

- `ValidatingAdmissionPolicy/safe-upgrades.gateway.networking.k8s.io`
- `ValidatingAdmissionPolicyBinding/safe-upgrades.gateway.networking.k8s.io`

It applies:

- `app.kubernetes.io/managed-by=Helm`
- `meta.helm.sh/release-name=envoy-gateway`
- `meta.helm.sh/release-namespace=networking`

RBAC permits only `get` and `patch` on those two named resources. Every Job container uses a restricted security context and the pinned Kubernetes 1.36.3 kubectl digest.

## Why

Envoy Gateway 1.9 rejects the deprecated BackendTrafficPolicy field and expects Helm ownership of the safe-upgrade admission objects. Applying these prerequisites while still on 1.8.3 separates adoption from the controller/chart upgrade and gives each change its own health gate.

## Validation

- Structural red/green check proved the policy field migration.
- Envoy app Kustomize client dry-run passed.
- Envoy app Flux build and server-side dry-run passed.
- Envoy config Flux build and server-side dry-run passed using Flux's `kustomize-controller` field manager, accurately exercising pruning of the old managed field.
- RBAC resource-name/verb assertions and all container security-context assertions passed.
- `git diff --check` passed.
- Envoy Gateway remains pinned to 1.8.3.

No application PVC, storage resource, Gateway API CRD, or workload image is changed.

## Post-merge gate

1. Reconcile only the Envoy app/config Kustomizations.
2. Require the adoption Job to complete and inspect every container log.
3. Verify live RBAC and exact Helm ownership metadata on both admission resources.
4. Confirm Envoy remains Ready on 1.8.3.
5. Run the Envoy 1.9 Helm server dry-run and Gateway/HTTPRoute/traffic health checks before considering the Renovate upgrade PR.