### PR TITLE
chore(envoy): migrate route storage to v1

### DIFF
--- a/kubernetes/networking/envoy-gateway/app/migration.yaml
+++ b/kubernetes/networking/envoy-gateway/app/migration.yaml
@@ -10,13 +10,16 @@ kind: ClusterRole
 metadata:
   name: envoy-gateway-migration
 rules:
-  - apiGroups: [admissionregistration.k8s.io]
-    resources: [validatingadmissionpolicies]
-    resourceNames: [safe-upgrades.gateway.networking.k8s.io]
-    verbs: [get, patch]
-  - apiGroups: [admissionregistration.k8s.io]
-    resources: [validatingadmissionpolicybindings]
-    resourceNames: [safe-upgrades.gateway.networking.k8s.io]
+  - apiGroups: [gateway.networking.k8s.io]
+    resources: [tcproutes, udproutes]
+    verbs: [get, list, patch]
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    resourceNames: [tcproutes.gateway.networking.k8s.io, udproutes.gateway.networking.k8s.io]
+    verbs: [get, watch]
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions/status]
+    resourceNames: [tcproutes.gateway.networking.k8s.io, udproutes.gateway.networking.k8s.io]
     verbs: [get, patch]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -35,14 +38,14 @@ subjects:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: envoy-gateway-adopt-safe-upgrades
+  name: envoy-gateway-migrate-route-storage-v1
   namespace: networking
 spec:
   backoffLimit: 2
   template:
     metadata:
       labels:
-        app.kubernetes.io/name: envoy-gateway-adopt-safe-upgrades
+        app.kubernetes.io/name: envoy-gateway-migrate-route-storage-v1
     spec:
       serviceAccountName: envoy-gateway-migration
       restartPolicy: Never
@@ -53,55 +56,91 @@ spec:
         seccompProfile:
           type: RuntimeDefault
       initContainers:
-        - name: label-policy
+        - name: verify-tcproute-v1-served
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [label, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, app.kubernetes.io/managed-by=Helm, --overwrite]
+          args: [wait, "--for=jsonpath={.spec.versions[?(@.name=='v1')].served}=true", crd/tcproutes.gateway.networking.k8s.io, --timeout=60s]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
-        - name: annotate-policy-release
+        - name: verify-tcproute-v1-storage
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [annotate, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-name=envoy-gateway, --overwrite]
+          args: [wait, "--for=jsonpath={.spec.versions[?(@.name=='v1')].storage}=true", crd/tcproutes.gateway.networking.k8s.io, --timeout=60s]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
-        - name: annotate-policy-namespace
+        - name: verify-udproute-v1-served
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [annotate, validatingadmissionpolicy, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-namespace=networking, --overwrite]
+          args: [wait, "--for=jsonpath={.spec.versions[?(@.name=='v1')].served}=true", crd/udproutes.gateway.networking.k8s.io, --timeout=60s]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
-        - name: label-binding
+        - name: verify-udproute-v1-storage
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [label, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, app.kubernetes.io/managed-by=Helm, --overwrite]
+          args: [wait, "--for=jsonpath={.spec.versions[?(@.name=='v1')].storage}=true", crd/udproutes.gateway.networking.k8s.io, --timeout=60s]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
-        - name: annotate-binding-release
+        - name: rewrite-tcproutes-v1
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [annotate, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-name=envoy-gateway, --overwrite]
+          args: [annotate, tcproutes.gateway.networking.k8s.io, --all, --all-namespaces, migration.home-server/storage-version=v1, --overwrite]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             capabilities:
               drop: [ALL]
-        - name: annotate-binding-namespace
+        - name: verify-and-clean-tcproutes-v1
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [annotate, validatingadmissionpolicybinding, safe-upgrades.gateway.networking.k8s.io, meta.helm.sh/release-namespace=networking, --overwrite]
+          args: [annotate, tcproutes.gateway.networking.k8s.io, --all, --all-namespaces, migration.home-server/storage-version-]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: rewrite-udproutes-v1
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, udproutes.gateway.networking.k8s.io, --all, --all-namespaces, migration.home-server/storage-version=v1, --overwrite]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: verify-and-clean-udproutes-v1
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [annotate, udproutes.gateway.networking.k8s.io, --all, --all-namespaces, migration.home-server/storage-version-]
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: set-tcproute-stored-version
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [patch, crd, tcproutes.gateway.networking.k8s.io, --subresource=status, --type=merge, -p, '{"status":{"storedVersions":["v1"]}}']
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: [ALL]
+        - name: set-udproute-stored-version
+          image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
+          command: [/bin/kubectl]
+          args: [patch, crd, udproutes.gateway.networking.k8s.io, --subresource=status, --type=merge, -p, '{"status":{"storedVersions":["v1"]}}']
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
@@ -111,7 +150,7 @@ spec:
         - name: verify
           image: registry.k8s.io/kubectl:v1.36.3@sha256:6e4fce3c83651edb91b74bc67701c5cd263dd8aa3cd4254b1798d6425a5ab789
           command: [/bin/kubectl]
-          args: [get, validatingadmissionpolicy/safe-upgrades.gateway.networking.k8s.io, validatingadmissionpolicybinding/safe-upgrades.gateway.networking.k8s.io]
+          args: [get, crd, tcproutes.gateway.networking.k8s.io, udproutes.gateway.networking.k8s.io]
           securityContext:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true


### PR DESCRIPTION
## What changed

Replace the completed Helm-adoption Job with a one-shot Gateway API storage-version migration for:

- `TCPRoute`
- `UDPRoute`

The Envoy Gateway chart remains v1.9.0.

## Migration ordering

The Job executes these steps sequentially:

1. Verify each CRD serves v1.
2. Verify each CRD stores new objects as v1.
3. Rewrite every TCPRoute through the v1 API by adding a temporary annotation.
4. Remove that annotation from every TCPRoute, proving the rewritten objects remain readable.
5. Repeat the rewrite and cleanup for every UDPRoute.
6. Only after all rewrites succeed, set each CRD's `status.storedVersions` to exactly `["v1"]`.
7. Read both CRDs as a final verification step.

The `--all --all-namespaces` commands are intentional and complete successfully even when the current route count is zero. They also cover any route created after this PR was authored but before the Job runs.

## RBAC and security

The migration ServiceAccount can only:

- `get/list/patch` TCPRoutes and UDPRoutes,
- `get/watch` the two named CRDs,
- `get/patch` the status subresource of those two named CRDs.

All ten init containers and the final verifier use the pinned Kubernetes 1.36.3 kubectl digest, a non-root pod context, read-only root filesystem, no privilege escalation, and all capabilities dropped.

## Safety boundary

This migration touches Gateway API route objects and the two CRD status fields only. It does not touch any application PVC, VolumeSnapshot, VolSync resource, Miroir resource, node volume, database, or application storage system.

## Validation

- Pre-change red check confirmed `storedVersions` still contains `v1alpha2`.
- TCPRoute and UDPRoute rewrite commands passed client dry-run parsing.
- Envoy app Kustomize client dry-run passed.
- Flux app build and server-side dry-run passed using Flux's `kustomize-controller` field manager.
- Exact RBAC, container ordering, security-context, and diff assertions passed.
- `git diff --check` passed.

## Post-merge gate

1. Reconcile only the Envoy app Kustomization.
2. Require the migration Job to complete and collect every init/app container log.
3. Verify all four live RBAC checks.
4. Assert both CRDs have `status.storedVersions == ["v1"]`.
5. Re-run Envoy HelmRelease, policy, Gateway, HTTPRoute-parent, and representative HTTPS traffic gates.
6. Retain a failed Job for diagnosis; do not clean it up on failure.