### PR TITLE
revert: defer Kubernetes 1.37 until Talos 1.14

### DIFF
--- a/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
+++ b/kubernetes/infra/tuppr/upgrades/kubernetes.yaml
@@ -7,7 +7,7 @@ metadata:
 spec:
     kubernetes:
         # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-        version: v1.37.0
+        version: v1.36.4
     healthChecks:
         - apiVersion: kopiur.home-operations.com/v1alpha1
           kind: Snapshot

--- a/talos/talconfig.yaml
+++ b/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 talosVersion: v1.13.9
 
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.37.0
+kubernetesVersion: v1.36.4
 
 clusterName: home-cluster
 endpoint: https://192.168.5.100:6443


### PR DESCRIPTION
Reverts #2237. Talos 1.13.9 rejects the Kubernetes 1.36 to 1.37 upgrade path, and Talos 1.14 GA is not yet published. Keep the declarative target at Kubernetes 1.36.4 until a stable Talos 1.14 upgrade can land first.